### PR TITLE
Change the ps arguments to avoid false positives

### DIFF
--- a/watchdog.js
+++ b/watchdog.js
@@ -987,9 +987,9 @@ console.log(`Flux daemon current: ${zelcash_remote_version.trim()} installed: ${
      console.log('Local version: '+zelcash_local_version.trim());
      console.log('Remote version: '+zelcash_remote_version.trim());
 
-     var  update_info = shell.exec("ps aux | grep 'apt' | wc -l",{ silent: true }).stdout;
+     var  update_info = shell.exec("ps auxc | grep 'apt' | wc -l",{ silent: true }).stdout;
 
-      if ( update_info > 2 ) {
+      if ( update_info > 0 ) {
 
         shell.exec("sudo killall apt",{ silent: true }).stdout;
         shell.exec("sudo killall apt-get",{ silent: true }).stdout;
@@ -1116,9 +1116,9 @@ async function flux_check() {
   console.log('UTC: '+data_time_utc+' | LOCAL: '+local );
   console.log('=================================================================');
 
-var  update_info = shell.exec("ps aux | grep 'apt' | wc -l",{ silent: true }).stdout;
+var  update_info = shell.exec("ps auxc | grep 'apt' | wc -l",{ silent: true }).stdout;
 
-if ( update_info > 2 ) {
+if ( update_info > 0 ) {
   console.log('Update detected...');
   console.log('Watchdog in sleep mode => '+data_time_utc);
   console.log('=================================================================');


### PR DESCRIPTION
On my stock Ubuntu install, watchdog was constantly in sleep mode, as the ps + grep was returning false positives from the thermald process:

> ~$ ps aux | grep 'apt' 
> root         701  0.0  0.1 125960  9040 ?        Ssl  Apr26   0:05 /usr/sbin/thermald --systemd --dbus-enable --adaptive
> fluxnode  638427  0.0  0.0   6608  2336 pts/1    S+   04:12   0:00 grep --color=auto apt 

Changing the arguments for ps to **auxc** only pulls the main process name. This avoids this false positive (and also doesn't self match the grep command). It still matches both apt & apt-get commands 

apt:
> ~$ ps auxc | grep 'apt'
> root      639990 58.5  0.7  70780 62320 pts/2    S+   04:15   0:01 apt 

apt-get:
> ~$ ps auxc | grep 'apt'
> root      640074 38.3  0.7  70824 62440 pts/2    S+   04:15   0:01 apt-get 