### PR TITLE
Fix broken fluxOsRootDir path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchdog",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "Watchdog for fluxnode",
   "main": "watchdog.js",
   "dependencies": {

--- a/watchdog.js
+++ b/watchdog.js
@@ -9,7 +9,7 @@ const axios = require('axios');
 const path = require('node:path');
 
 sleep.sleep(15);
-console.log('Watchdog v6.3.1 Starting...');
+console.log('Watchdog v6.3.2 Starting...');
 console.log('=================================================================');
 
 const configPath = 'config.js';

--- a/watchdog.js
+++ b/watchdog.js
@@ -16,13 +16,9 @@ const configPath = 'config.js';
 
 const isArcane = Boolean(process.env.FLUXOS_PATH);
 const fluxdConfigPath = process.env.FLUXD_CONFIG_PATH;
-const fluxOsRootDir = process.env.FLUXOS_PATH;
 const fluxbenchPath = process.env.FLUXBENCH_PATH;
-
-const fluxOsConfigPath = isArcane
-  ? path.join(fluxOsRootDir, "config/userconfig.js")
-  : "/home/$USER/zelflux/config/userconfig.js";
-
+const fluxOsRootDir = process.env.FLUXOS_PATH || "/home/$USER/zelflux";
+const fluxOsConfigPath = path.join(fluxOsRootDir, "config/userconfig.js")
 const fluxdServiceName = isArcane ? "fluxd.service" : "zelcash.service";
 
 var sync_lock = 0;
@@ -917,9 +913,7 @@ async function auto_update() {
     ? `cd ${fluxOsRootDir} && npm install --omit=dev --cache /dat/usr/lib/npm`
     : ":";
 
-  const fluxOsPkgFile = isArcane
-    ? path.join(fluxOsRootDir, "package.json")
-    : "/home/$USER/zelflux/package.json";
+  const fluxOsPkgFile = path.join(fluxOsRootDir, "package.json");
 
   delete require.cache[require.resolve('./config.js')];
   var config = require('./config.js');


### PR DESCRIPTION
As title.

fluxOsRootDir wasn't set for non Arcane nodes.

Have tidied this up. Tested on a node

```
=================================================================
Config file:
Tier: STRATUS
Minimum eps: 0
Fix action:  enabled
Discord alert:  enabled
Discord ping:  enabled
Telegram alert:  disabled
Update settings:
=> Flux daemon:  enabled
=> Fluxbench: enabled
=> FluxOS:  enabled
=================================================================
 UPDATE CHECKING....
=================================================================
Watchdog current: 6.3.1 installed: 6.3.1
FluxOS current: 5.36.0 installed: 5.35.0
New FluxOS version detected:
=================================================================
Local version: 5.35.0
Remote version: 5.36.0
=================================================================
Update successfully.

Flux daemon current: 7.2.0 installed: 7.2.0
Fluxbench current: 4.0.1 installed: 4.0.1
=================================================================
```