### PR TITLE
Remove restart benchmark from watchdog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "watchdog",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "Watchdog for fluxnode",
   "main": "watchdog.js",
   "dependencies": {


### PR DESCRIPTION
Fluxbench have built in functionalities that auto restart the benchmarks after 5 minutes it failed.
We are removing from watchdog the responsability to restart the fluxbench after it detects it failed.

What was changed:
- When watchdog detects benchmark failure, doesn't call the rcp to restart the benchmarks, and sends a webhook saying the benchmark will be restarted in the next few minutes;
- Don't detect a false new failure benchmark if the time of the failure is the same as last check.